### PR TITLE
Bug: Fix re-render list following delete of favourite query

### DIFF
--- a/src/components/list/list.jsx
+++ b/src/components/list/list.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import mongodbns from 'mongodb-ns';
@@ -7,7 +7,7 @@ import { Card, CardBody } from 'components/card';
 import styles from './list.less';
 
 const factory = (ListItem, Saving) => {
-  class List extends PureComponent {
+  class List extends Component {
     static displayName = 'QueryHistoryList';
 
     static propTypes = {


### PR DESCRIPTION
Changed List to be a Component rather than a PureComponent in order to fix the component from not re-rendering following a delete of a favourite.