### PR TITLE
Fix style bugs, add tooltip

### DIFF
--- a/src/components/card/card.less
+++ b/src/components/card/card.less
@@ -16,9 +16,12 @@
   }
 }
 
-.component-header,
+.component-header {
+  padding: 10px 10px 0 10px;
+}
+
 .component-body {
-  padding: 11px;
+  padding: 10px;
 }
 
 .component-header {
@@ -27,7 +30,7 @@
   align-items: center;
   justify-content: flex-end;
   position: relative;
-  min-height: 50px;
+  min-height: 32px;
 }
 
 .component-header-inner {

--- a/src/components/code/code.less
+++ b/src/components/code/code.less
@@ -14,6 +14,10 @@
   word-wrap: break-word;
   white-space: pre;
   font-size: 11px;
+  
+  &::-webkit-scrollbar { 
+    display: none; 
+  }
 
   :global {
     .hljs-string {

--- a/src/components/favorite/favorite-list-item.jsx
+++ b/src/components/favorite/favorite-list-item.jsx
@@ -44,7 +44,7 @@ class FavoriteListItem extends PureComponent {
           <button
             title="Copy Query to Clipboard"
             data-test-id="query-history-button-copy-query"
-            className={classnames('btn', 'btn-sm', 'btn-default', styles.button, styles['button-copy'])}
+            className={classnames('btn', 'btn-xs', 'btn-default', styles.button, styles['button-copy'])}
             onClick={this.copyQuery}>
             <FontAwesome name="clipboard"/>
           </button>
@@ -52,7 +52,7 @@ class FavoriteListItem extends PureComponent {
           <button
             title="Delete Query from Favorites List"
             data-test-id="query-history-button-delete-fav"
-            className={classnames('btn', 'btn-sm', 'btn-default', styles.button)}
+            className={classnames('btn', 'btn-xs', 'btn-default', styles.button)}
             onClick={this.deleteFavorite}>
             <FontAwesome name="trash"/>
           </button>

--- a/src/components/favorite/favorite-list-item.less
+++ b/src/components/favorite/favorite-list-item.less
@@ -1,6 +1,6 @@
 .button {
   padding: 0 !important;
-  width: 28px;
+  width: 24px;
   margin-left: 5px;
 }
 
@@ -8,8 +8,8 @@
   &:focus {
     &:after {
       position: absolute;
-      margin-top: 35px;
-      right: 11px;
+      margin-top: 25px;
+      right: 22px;
       border-radius: 3px;
       color: white;
       padding: 2px 10px 2px 10px;

--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import FontAwesome from 'react-fontawesome';
 import { ViewSwitcher } from 'hadron-react-components';
 
 import styles from './header.less';
@@ -62,7 +61,7 @@ class Header extends PureComponent {
               data-test-id="query-history-button-close-panel"
               href="#"
               onClick={this.collapse}>
-          <FontAwesome name="times"/>
+          ×
         </span>
       </div>
     );

--- a/src/components/header/header.less
+++ b/src/components/header/header.less
@@ -27,6 +27,7 @@
 
 .close {
   margin-left: auto;
+  font-weight: bold;
 
   &:hover {
     cursor: pointer;

--- a/src/components/list/list.less
+++ b/src/components/list/list.less
@@ -11,7 +11,7 @@
 }
 
 .item {
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 
   &:last-child,
   &:only-child {

--- a/src/components/recent/recent-list-item.jsx
+++ b/src/components/recent/recent-list-item.jsx
@@ -49,7 +49,7 @@ class RecentListItem extends PureComponent {
           <button
             title="Favorite Query"
             data-test-id="query-history-button-fav"
-            className={classnames('btn', 'btn-sm', 'btn-default', styles.button)}
+            className={classnames('btn', 'btn-xs', 'btn-default', styles.button)}
             onClick={this.saveRecent}>
             <FontAwesome name="star-o"/>
           </button>
@@ -57,7 +57,7 @@ class RecentListItem extends PureComponent {
           <button
             title="Copy Query to Clipboard"
             data-test-id="query-history-button-copy-query"
-            className={classnames('btn', 'btn-sm', 'btn-default', styles.button, styles['button-copy'])}
+            className={classnames('btn', 'btn-xs', 'btn-default', styles.button, styles['button-copy'])}
             onClick={this.copyQuery}>
             <FontAwesome name="clipboard"/>
           </button>
@@ -65,7 +65,7 @@ class RecentListItem extends PureComponent {
           <button
             title= "Delete Query from Recent List"
             data-test-id="query-history-button-delete-recent"
-            className={classnames('btn', 'btn-sm', 'btn-default', styles.button)}
+            className={classnames('btn', 'btn-xs', 'btn-default', styles.button)}
             onClick={this.deleteRecent}>
             <FontAwesome name="trash"/>
           </button>

--- a/src/components/recent/recent-list-item.less
+++ b/src/components/recent/recent-list-item.less
@@ -1,6 +1,6 @@
 .button {
   padding: 0 !important;
-  width: 28px;
+  width: 24px;
   margin-left: 5px;
 }
 
@@ -8,8 +8,8 @@
   &:focus {
     &:after {
       position: absolute;
-      margin-top: 35px;
-      right: 11px;
+      margin-top: 25px;
+      right: 22px;
       border-radius: 3px;
       color: white;
       padding: 2px 10px 2px 10px;

--- a/src/components/saving/saving.less
+++ b/src/components/saving/saving.less
@@ -9,13 +9,10 @@
   border-radius: 2px;
   height: 28px;
   outline: 0;
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
   padding: 0px 5px 0px 5px;
 
   &:focus {
     border-color: #5CAEEB;
-    color: #006CBC;
   }
 }
 

--- a/src/components/toggle-query-history-button/toggle-query-history-button.jsx
+++ b/src/components/toggle-query-history-button/toggle-query-history-button.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import FontAwesome from 'react-fontawesome';
 import Actions from 'actions';
+import ReactTooltip from 'react-tooltip';
 
 import styles from './toggle-query-history-button.less';
 
@@ -27,11 +28,18 @@ class ToggleQueryHistoryButton extends PureComponent {
           className={classnames('btn', 'btn-default', 'btn-sm', styles.component)}
           data-test-id="query-history-button"
           type="button"
-          onClick={this.handleCollapse}>
+          onClick={this.handleCollapse}
+          data-tip="Past and Favorite Queries">
           <FontAwesome
             data-test-id="query-history-button-icon"
             name="history"
-            className="query-history-button-icon"/>
+            className="query-history-button-icon"
+          />
+          <ReactTooltip
+            place="top"
+            type="dark"
+            effect="solid"
+            className={styles.tooltip}/>
         </button>
     );
   }

--- a/src/components/toggle-query-history-button/toggle-query-history-button.less
+++ b/src/components/toggle-query-history-button/toggle-query-history-button.less
@@ -1,12 +1,11 @@
 .component {
 	padding: 0;
 	margin-left: 5px;
-	border-top-right-radius: 0;
-	border-bottom-right-radius: 0;
-	border-right: 0;
-	width: 24px;
+	width: 28px;
+}
 
-	&:hover, &:focus {
-		border-right: 0;
-	}
+.tooltip {
+  text-transform: none;
+  font-weight: normal;
+  padding: 2px 10px;
 }


### PR DESCRIPTION
**Overview:**

- This PR is a small style pass that (a) fixes a few bugs introduced during the plugin conversion and (b) adds other minor changes that improve the overall experience

**Change Log:**

- Make query history button more prominent; remove 0 border radius
- Add a tool tip to the query history button to explain what it does
- Make card action buttons smaller
- Remove unnecessary padding from cards
- Remove border radius on favorite input and prevent focus text from turning blue
- Swap out wonky font awesome close icon with a standard html entity
- Remove scrollbars from code snippets
- Reduce spacing between query history cards to fit more information on the page

![screen shot 2017-11-09 at 9 14 45 am](https://user-images.githubusercontent.com/1957226/32625327-fa9765d2-c559-11e7-9648-cf852dfbdb39.png)
![screen shot 2017-11-09 at 9 15 43 am](https://user-images.githubusercontent.com/1957226/32625356-01966c16-c55a-11e7-8162-9b07dbe00fcf.png)
