### PR TITLE
COMPASS-2403 - Change Query History Icon

### DIFF
--- a/src/components/toggle-query-history-button/toggle-query-history-button.jsx
+++ b/src/components/toggle-query-history-button/toggle-query-history-button.jsx
@@ -32,7 +32,7 @@ class ToggleQueryHistoryButton extends PureComponent {
           data-tip="Past and Favorite Queries">
           <FontAwesome
             data-test-id="query-history-button-icon"
-            name="history"
+            name="clock-o"
             className="query-history-button-icon"
           />
           <ReactTooltip

--- a/src/components/toggle-query-history-button/toggle-query-history-button.spec.js
+++ b/src/components/toggle-query-history-button/toggle-query-history-button.spec.js
@@ -31,7 +31,7 @@ describe('ToggleQueryHistoryButton [Component]', () => {
       const node = component.find('[data-test-id="query-history-button-icon"]');
 
       expect(node).to.have.type(FontAwesome);
-      expect(node.prop('name')).to.equal('history');
+      expect(node.prop('name')).to.equal('clock-o');
     });
   });
 });


### PR DESCRIPTION
[COMPASS-2403](https://jira.mongodb.org/browse/COMPASS-2403): Users have been getting confused between the current query history icon (`fa-history`) and the refresh button. Both icons look similar in structure and are positioned near each other.

This PR replaces `fa-history` with `fa-clock-o`, which should add more visual distinction. 
![screen shot 2018-01-11 at 11 25 18 am](https://user-images.githubusercontent.com/1957226/34842134-90bd1a2a-f6d8-11e7-838d-3cf968a5af36.png)
