### PR TITLE
[WIP] COMPASS-3839: add a runQuery localAppRegistry event

### DIFF
--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -19,6 +19,7 @@ global.hadronApp.appRegistry = appRegistry;
 
 // Activate our plugin with the Hadron App Registry
 activate(appRegistry);
+appRegistry.onActivated();
 
 // Since we are using HtmlWebpackPlugin WITHOUT a template,
 // we should create our own root node in the body element before rendering into it.
@@ -27,8 +28,10 @@ root.id = 'root';
 document.body.appendChild( root );
 
 const actions = configureActions();
+const localAppRegistry = new AppRegistry();
+
 const store = configureStore({
-  localAppRegistry: new AppRegistry(),
+  localAppRegistry: localAppRegistry,
   namespace: 'echo.artists',
   actions: actions
 });
@@ -44,6 +47,20 @@ const render = Component => {
 };
 
 // Render our plugin
+localAppRegistry.emit('toggle-query-history');
+// set up a recent query and a favourite query for debugging
+const query = {
+  filter: { name: 'Chashu' },
+  project: {},
+  sort: {},
+  collation: {},
+  skip: {},
+  limit: {},
+  maxTimeMS: 1000,
+  ns: 'echo.artists'
+};
+
+localAppRegistry.emit('query-applied', query);
 render( QueryHistoryPlugin );
 
 if (module.hot) {

--- a/src/stores/query-history-store.js
+++ b/src/stores/query-history-store.js
@@ -46,6 +46,10 @@ const configureStore = (options = {}) => {
       });
     },
 
+    runQuery(attrs) {
+      this.localAppRegistry('auto-populate-query', attrs);
+    },
+
     toggleCollapse() {
       this.setState({
         collapsed: !this.state.collapsed


### PR DESCRIPTION
## Description
Nothing happens when `runQuery` is called in our jsx component. This PR adds an existing event that `query-bar` listens to.

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Open Questions
I have not been able to run this to double check if it _actually_ works, so the `TODO` here is to double check!

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)